### PR TITLE
[back] Question 검색 (페이지네이션 + 키워드별 검색) 구현

### DIFF
--- a/codearea/src/main/java/sample/codearea/controller/QuestionController.java
+++ b/codearea/src/main/java/sample/codearea/controller/QuestionController.java
@@ -2,36 +2,98 @@ package sample.codearea.controller;
 
 import jakarta.validation.Valid;
 import java.util.Optional;
+import org.hibernate.query.SortDirection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.Sort.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import sample.codearea.dto.PaginatedQuestionPreviewListRequestDto;
+import sample.codearea.dto.PaginatedQuestionPreviewListResponseDto;
+import sample.codearea.dto.PaginationResponseDto;
+import sample.codearea.entity.QuestionEntity;
+import sample.codearea.service.QuestionMapper;
+import sample.codearea.service.QuestionService;
 
 @Controller
 @RequestMapping("/questions")
 public class QuestionController {
 
+	private final QuestionService questionService;
+
+	public QuestionController(QuestionService questionService) {
+		this.questionService = questionService;
+	}
+
+	// * 여러개의 Reqeust Param중에서 1개만 들어옴을 어떻게 보장해야 할지?
+	//	     ex) GET /questions?title={?}&content={?}&nickname={?}&email={?}
+	//       1. 4개의 Request Param 중 반드시 1개만 들어 온다.
+	//          ex) /question?title=java
+	//          ex) /question?nickname=김영한
+	//       2. 만약 검색 조건이 2개 이상 들어오면, 예외를 발생
+
 	@GetMapping("")
 	public ResponseEntity<?> getQuestions(
-		@RequestParam(value = "title") Optional<String> title,
-		@RequestParam(value = "content") Optional<String> content,
-		@RequestParam(value = "email") Optional<String> email,
-		@RequestParam(value = "nickname") Optional<String> nickname,
+		@RequestParam(value = "category") Optional<String> searchCategory,
+		@RequestParam(value = "search") Optional<String> searchString,
 		@RequestBody @Valid PaginatedQuestionPreviewListRequestDto requestDto
 	) {
-		//	GET /questions?title={?}&content={?}&nickname={?}&email={?}
 
-		//  1. 4개의 Request Param 중 반드시 1개만 들어 옵니다
-		//     ex) /question?title=java
-		//     ex) /question?nickname=김영한
-		//     - 만약 검색 조건이 2개 이상 들어오면, 예외를 발생시킵니다.
+		PaginatedQuestionPreviewListResponseDto responseDto = new PaginatedQuestionPreviewListResponseDto();
 
-		//  2. reqeustDto에는 정렬 조건이 들어옵니다.
-		//     조회수, 싫어요 수, 좋아요 수로 정렬합니다.
+		Sort sortStrategy = Sort.by(Direction.DESC, requestDto.getSort().getTarget());
 
-		return ResponseEntity.ok(requestDto);
+		if ( searchCategory.isPresent() && searchString.isPresent() ) {
+			Page<QuestionEntity> result = questionService
+				.getQuestionsByContainingStringWithPagingAndSorting(
+					searchCategory.get(),
+					searchString.get(),
+					requestDto.getPagination().getCurrentPage(),
+					requestDto.getPagination().getPageSize(),
+					sortStrategy
+				);
+
+			responseDto.setPagination(
+				PaginationResponseDto.builder()
+									 .currentPage(result.getNumber())
+									 .totalPage(result.getTotalPages())
+									 .build()
+			);
+
+			responseDto.setQuestionPreviews(
+				result.getContent()
+					  .stream().map(QuestionMapper::toQuestionPreviewDto)
+					  .toList()
+			);
+
+			return ResponseEntity.ok(responseDto);
+		}
+
+		Page<QuestionEntity> result = questionService
+			.getQuestionsWithPagingAndSorting(
+				requestDto.getPagination().getCurrentPage(),
+				requestDto.getPagination().getPageSize(),
+				sortStrategy
+			);
+
+		responseDto.setPagination(
+			PaginationResponseDto.builder()
+								 .currentPage(result.getNumber())
+								 .totalPage(result.getTotalPages())
+								 .build()
+		);
+		responseDto.setQuestionPreviews(
+			result.getContent()
+				  .stream().map(QuestionMapper::toQuestionPreviewDto)
+				  .toList()
+		);
+
+		return ResponseEntity.ok(responseDto);
 	}
 }

--- a/codearea/src/main/java/sample/codearea/dto/SortRequestDto.java
+++ b/codearea/src/main/java/sample/codearea/dto/SortRequestDto.java
@@ -16,9 +16,11 @@ import lombok.ToString;
 @Builder
 public class SortRequestDto {
 
+	static final String DEFAULT_SORT_STRATEGY = "createdAt";
+
 	@Pattern(
-		regexp = "^(views|likes|hates)$",
+		regexp = "^(createdAt|views|likes|hates)$",
 		message = "정렬이 불가능한 옵션입니다"
 	)
-	private String target;
+	private String target = DEFAULT_SORT_STRATEGY;
 }

--- a/codearea/src/main/java/sample/codearea/repository/QuestionRepository.java
+++ b/codearea/src/main/java/sample/codearea/repository/QuestionRepository.java
@@ -1,12 +1,44 @@
 package sample.codearea.repository;
 
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import sample.codearea.entity.QuestionEntity;
+import sample.codearea.entity.UserEntity;
 
+// 1. 조건 검색 (email, nickname, title, content)
+// 2. 정렬 (조회순, 좋아요 순, 싫어요 순)
 @Repository
 public interface QuestionRepository extends JpaRepository<QuestionEntity, Long> {
-	// 1. 조건 검색 (email, nickname, title, content)
 
-	// 2. 정렬 (조회순, 좋아요 순, 싫어요 순)
+
+	Page<QuestionEntity> findAllByUserEntity_EmailContaining(String email, PageRequest pageRequest);
+
+	Page<QuestionEntity> findAllByUserEntity_NicknameContaining(String nickname, PageRequest pageRequest);
+
+	Page<QuestionEntity> findAllByTitleContaining(String title, PageRequest pageRequest);
+
+	Page<QuestionEntity> findAllByContentContaining(String content, PageRequest pageRequest);
 }
+
+// https://docs.spring.io/spring-data/jpa/reference/jpa/query-methods.html
+// https://stackoverflow.com/questions/21456494/spring-jpa-query-with-like
+// https://www.baeldung.com/spring-data-jpa-query
+// https://www.baeldung.com/spring-data-sorting
+/*
+	@Query("SELECT q FROM QuestionEntity q "
+		+ "WHERE q.user.nickname LIKE CONCAT('%', :nickname, '%') "
+		+ "ORDER BY q.views DESC")
+	Page<QuestionEntity> findQuestionsByNickname(@Param("nickname") String nickname, Pageable pageable);
+
+	@Query("SELECT q FROM QuestionEntity q "
+		+ "WHERE q.user.email LIKE CONCAT('%', :email, '%') "
+		+ "ORDER BY q.views DESC")
+	Page<QuestionEntity> findQuestionsByEmail(@Param("email") String email, Pageable pageable);
+ */

--- a/codearea/src/main/java/sample/codearea/service/QuestionMapper.java
+++ b/codearea/src/main/java/sample/codearea/service/QuestionMapper.java
@@ -1,0 +1,23 @@
+package sample.codearea.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import sample.codearea.dto.QuestionPreviewResponseDto;
+import sample.codearea.entity.QuestionEntity;
+import sample.codearea.repository.QuestionRepository;
+
+public class QuestionMapper {
+	public static QuestionPreviewResponseDto toQuestionPreviewDto(QuestionEntity questionEntity) {
+		return QuestionPreviewResponseDto.builder()
+										 .questionId(questionEntity.getId())
+										 .title(questionEntity.getTitle())
+										 .nickname(questionEntity.getUser().getNickname())
+										 .createAt(questionEntity.getCreatedAt())
+										 .likes(questionEntity.getLikes())
+										 .hates(questionEntity.getHates())
+										 .views(questionEntity.getViews())
+										 .build();
+	}
+}

--- a/codearea/src/main/java/sample/codearea/service/QuestionService.java
+++ b/codearea/src/main/java/sample/codearea/service/QuestionService.java
@@ -1,8 +1,66 @@
 package sample.codearea.service;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
+import sample.codearea.entity.QuestionEntity;
+import sample.codearea.repository.QuestionRepository;
 
 @Service
 public class QuestionService {
 
+	private final QuestionRepository questionRepository;
+
+	public QuestionService(QuestionRepository questionRepository) {
+		this.questionRepository = questionRepository;
+	}
+
+	public Page<QuestionEntity> getQuestionsWithPagingAndSorting(
+		Integer pageNumber,
+		Integer pageSize,
+		Sort sortingStrategy
+	) {
+		return questionRepository.findAll(
+			PageRequest.of(
+				pageNumber,
+				pageSize,
+				sortingStrategy
+			)
+		);
+	}
+
+	public Page<QuestionEntity> getQuestionsByContainingStringWithPagingAndSorting(
+		String searchCategory,
+		String searchString,
+		Integer pageNumber,
+		Integer pageSize,
+		Sort sortingStrategy
+	) {
+		// TODO : do parameter validation
+
+		PageRequest pageRequest = PageRequest.of(
+			pageNumber,
+			pageSize,
+			sortingStrategy
+		);
+
+		switch (searchCategory) {
+			case ("email"):
+				return questionRepository.findAllByUserEntity_EmailContaining(searchString, pageRequest);
+			case ("nickname"):
+				return questionRepository.findAllByUserEntity_NicknameContaining(searchString, pageRequest);
+			case ("title"):
+				return questionRepository.findAllByTitleContaining(searchString, pageRequest);
+			case ("content"):
+				return questionRepository.findAllByContentContaining(searchString, pageRequest);
+			default:
+				throw new IllegalArgumentException("Invalid search category: " + searchCategory);
+		}
+	}
 }


### PR DESCRIPTION
issue #11 

질문 검색 기능 입니다.
데이터 추가되면 테스트 진행 예정입니다.

### Question Search API
```typescript
// 닉네임에 minky가 포함되는 모든 질문들을 반환합니다.
GET /questions?category={'nickname'}&search=${'minky'}

// request parameter
//   - category : nickname | email | title | content
//   - search : 검색할 문자열 ( --> target.contains('문자열') )
```
### Resquest Body
```typescript
{
    pagination : {
        currentPage,             // 몇번째 페이지인지
        pageSize,         // 한 페이지에 몇개가 들어가는지 
    },
    
    // sort target이 없을 경우 기본 정렬 전략은 (질문 생성 시간 최신순) 입니다.
    sort : {            
        target : "createAt" | "views" | "likes" | "hates"   // Defaults to "createAt"
    }
}
```
### Response Body
```typescript
{
    pagination: {
        currentPage,      // 몇번째 페이지인지
        totalPage,       // 전체 페이지 총 개수
    },
    // 질문 내용 미리보기 UI를 위한 데이터입니다.
    questionPreviews: [
        {
            questionId: // 프리뷰 페이지에서 클릭 시, 해당 질문 ID를 이용해 본문을 받습니다. 
            title:
            nickname:
            createdAt:
            likes:      // 좋아요 개수
            hates:   // 싫어요 개수
            views:      // 조회 수
        },
        // ...
    ]
}
```