### PR TITLE
[back] fix: update anwerResponseDto and related methods

### DIFF
--- a/codearea/src/main/java/sample/codearea/dto/AnswerResponseDto.java
+++ b/codearea/src/main/java/sample/codearea/dto/AnswerResponseDto.java
@@ -1,6 +1,7 @@
 package sample.codearea.dto;
 
 import lombok.*;
+import sample.codearea.constant.voteStatus;
 
 import java.time.LocalDateTime;
 
@@ -12,9 +13,12 @@ import java.time.LocalDateTime;
 @Builder
 public class AnswerResponseDto {
 
+    private Long userId;
     private Long answerId;
     private String nickname;
     private LocalDateTime modifiedAt;
     private String content;
+    private voteStatus voteStatus;
+    private Boolean scrapStatus;
 
 }

--- a/codearea/src/main/java/sample/codearea/service/AnswerConverter.java
+++ b/codearea/src/main/java/sample/codearea/service/AnswerConverter.java
@@ -1,6 +1,7 @@
 package sample.codearea.service;
 
 import org.springframework.stereotype.Service;
+import sample.codearea.constant.voteStatus;
 import sample.codearea.dto.AnswerRequestDto;
 import sample.codearea.dto.AnswerResponseDto;
 import sample.codearea.entity.AnswerEntity;
@@ -8,12 +9,15 @@ import sample.codearea.entity.AnswerEntity;
 @Service
 public class AnswerConverter {
 
-    public AnswerResponseDto toDto(AnswerEntity entity) {
+    public static AnswerResponseDto toDto(AnswerEntity entity, voteStatus voteStatus, boolean scrapStatus) {
         return AnswerResponseDto.builder()
+                .userId(entity.getUser().getId())
                 .answerId(entity.getId())
                 .nickname(entity.getUser().getNickname())
                 .modifiedAt(entity.getUpdatedAt())
                 .content(entity.getContent())
+                .voteStatus(voteStatus)
+                .scrapStatus(scrapStatus)
                 .build();
     }
 

--- a/codearea/src/main/java/sample/codearea/service/AnswerService.java
+++ b/codearea/src/main/java/sample/codearea/service/AnswerService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import sample.codearea.constant.SessionConst;
+import sample.codearea.constant.voteStatus;
 import sample.codearea.dto.AnswerRequestDto;
 import sample.codearea.dto.AnswerResponseDto;
 import sample.codearea.entity.AnswerEntity;
@@ -15,6 +16,7 @@ import sample.codearea.repository.AnswerRepository;
 import sample.codearea.repository.QuestionRepository;
 import sample.codearea.repository.UserRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -37,9 +39,13 @@ public class AnswerService {
     }
 
     public List<AnswerResponseDto> findAll(Long questionId) {
-        return answerRepository.findByQuestionId(questionId).stream()
-                .map(answerConverter::toDto)
-                .collect(Collectors.toList());
+        List<AnswerEntity> byQuestionId = answerRepository.findByQuestionId(questionId);
+
+        List<AnswerResponseDto> answerResponseDtoList = new ArrayList<>();
+        for (AnswerEntity answerEntity : byQuestionId) {
+            answerResponseDtoList.add(AnswerConverter.toDto(answerEntity, voteStatus.VOTE_STATUS_NOT_VOTED, false));
+        }
+        return answerResponseDtoList;
     }
 
     public AnswerResponseDto save(Long questionId, AnswerRequestDto answerRequestDto, HttpServletRequest httpServletRequest) {
@@ -58,7 +64,7 @@ public class AnswerService {
         AnswerEntity save = answerRepository.save(answer);
 
         // entity to response dto
-        AnswerResponseDto answerResponseDto = answerConverter.toDto(save);
+        AnswerResponseDto answerResponseDto = answerConverter.toDto(save, voteStatus.VOTE_STATUS_NOT_VOTED, false);
 
         return answerResponseDto;
     }


### PR DESCRIPTION
#50

- AnswerResponse 에 voteStatus와 scrapStatus 데이터 추가
-  관련 dto 변환 등을 처리